### PR TITLE
datahike-postgres uses new configuration format and supports ssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,29 +21,27 @@ Add to your leiningen dependencies:
 
 [![Clojars Project](http://clojars.org/io.replikativ/datahike-postgres/latest-version.svg)](http://clojars.org/io.replikativ/datahike-postgres)
 
-After including the datahike API and the datahike-postgres namespace, you can use the Postgres backend now using the keyword `:pg`
+After including the datahike API and the datahike-postgres namespace, you can use the Postgres backend now using the keyword `:pg`. Please refer to [the documentation of datahikes configuration in the corresponding repository.](https://github.com/replikativ/datahike/blob/master/doc/config.md). An example configuration:
 
 ```clojure
 (ns project.core
   (:require [datahike.api :as d]
+            [datahike.config :as c]
             [datahike-postgres.core]))
 
-;; Create a config map with postgres as storage medium
-(def config {:backend :pg
-             :host "localhost"
-             :port 5432
-             :username "alice"
-             :password "foo"
-             :path "/example-db"})
-
-;; Alternatively, use an URI as configuration
-;; (def config "datahike:pg://alice:foo@localhost:5432/example-db")
+;; Reload configuration with your parameters
+(c/reload-config {:backend :pg
+                  :host "localhost"
+                  :port 5432
+                  :username "alice"
+                  :password "foo"
+                  :dbname "example-db"})
 
 ;; Create a database at this place, by default configuration we have a strict
 ;; schema and temporal index
-(d/create-database config)
+(d/create-database)
 
-(def conn (d/connect config))
+(def conn (d/connect))
 
 ;; The first transaction will be the schema we are using:
 (d/transact conn [{:db/ident :name
@@ -68,7 +66,7 @@ After including the datahike API and the datahike-postgres namespace, you can us
 ;; => #{[3 "Alice" 20] [4 "Bob" 30] [5 "Charlie" 40]}
 
 ;; Clean up the database if it is not needed any more
-(d/delete-database config)
+(d/delete-database)
 ```
 
 

--- a/src/datahike_postgres/core.clj
+++ b/src/datahike_postgres/core.clj
@@ -4,18 +4,27 @@
             [konserve-pg.core :as kp]
             [superv.async :refer [<?? S]]))
 
-(defn pg-path [{:keys [username password host port path]}]
-  (clojure.string/join ["postgres://" username ":" password "@" host ":" port path]))
+(defn convert-config
+  "convert datahike config to clojure.java.jdbc config"
+  [{:keys [username password host port dbname ssl sslfactory]}]
+  {:dbtype "postgresql"
+   :user username
+   :password password
+   :host host
+   :port port
+   :dbname dbname
+   :ssl ssl
+   :sslfactory sslfactory})
 
 (defmethod empty-store :pg [config]
   (kons/add-hitchhiker-tree-handlers
-   (<?? S (kp/new-pg-store (pg-path config)))))
+   (<?? S (kp/new-pg-store (convert-config config)))))
 
 (defmethod delete-store :pg [config]
-  (kp/delete-store (pg-path config)))
+  (kp/delete-store (convert-config config)))
 
 (defmethod connect-store :pg [config]
-  (<?? S (kp/new-pg-store (pg-path config))))
+  (<?? S (kp/new-pg-store (convert-config config))))
 
 (defmethod scheme->index :pg [_]
   :datahike.index/hitchhiker-tree)

--- a/test/datahike_postgres/core_test.cljc
+++ b/test/datahike_postgres/core_test.cljc
@@ -5,21 +5,27 @@
     [datahike.api :as d]
     [datahike-postgres.core]))
 
+(deftest test-postgres-store-config
+  (let [config {:backend :pg
+                :username "alice"
+                :password "foo"
+                :host "localhost"
+                :port 5432
+                :dbname "config-test"
+                :ssl false
+                :sslfactory "foobar"}
+        _ (d/delete-database config)]
+    (is (not (d/database-exists? config)))
+    (let [_ (d/create-database config :schema-on-read true)
+          conn (d/connect config)]
 
-(deftest test-postgres-store
-  (let [uri "datahike:pg://alice:foo@localhost:5432/config-test"
-        _ (d/delete-database uri)]
-    (is (not (d/database-exists? uri)))
-    (let [_ (d/create-database uri :schema-on-read true)
-          conn (d/connect uri)]
-
-      (d/transact conn [{ :db/id 1, :name  "Ivan", :age   15 }
-                        { :db/id 2, :name  "Petr", :age   37 }
-                        { :db/id 3, :name  "Ivan", :age   37 }
-                        { :db/id 4, :age 15 }])
+      (d/transact conn [{ :db/id 1, :name  "Ivan", :age   15}
+                        { :db/id 2, :name  "Petr", :age   37}
+                        { :db/id 3, :name  "Ivan", :age   37}
+                        { :db/id 4, :age 15}])
       (is (= (d/q '[:find ?e :where [?e :name]] @conn)
              #{[3] [2] [1]}))
 
       (d/release conn)
-      (is (d/database-exists? uri))
-      (d/delete-database uri))))
+      (is (d/database-exists? config))
+      (d/delete-database config))))


### PR DESCRIPTION
I added the support for ssl-connections to this library and due
to changes to datahike config and simplicity I chose to switch
the configuration format to map from now on.

- Closes https://github.com/replikativ/datahike/issues/133
- Refers #2